### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/agathedupuis/e4c3b352-d44c-489d-a397-3eb40531628a/783d9572-8a2d-47df-862e-79659cbe2f0e/_apis/work/boardbadge/3e50aaec-0b0f-41e4-bd5d-e0c4f482b139)](https://dev.azure.com/agathedupuis/e4c3b352-d44c-489d-a397-3eb40531628a/_boards/board/t/783d9572-8a2d-47df-862e-79659cbe2f0e/Microsoft.RequirementCategory)
 # React + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/agathedupuis/e4c3b352-d44c-489d-a397-3eb40531628a/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.